### PR TITLE
Revert "Bump worldguard-bukkit from 7.0.4 to 7.0.6"

### DIFF
--- a/implementation/v7/pom.xml
+++ b/implementation/v7/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>com.sk89q.worldguard</groupId>
             <artifactId>worldguard-bukkit</artifactId>
-            <version>7.0.6</version>
+            <version>7.0.4</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
Downgrades to 7.0.4, because 7.0.6 requires Java 16...